### PR TITLE
feat(ui): create interface to view the fragment

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@radix-ui/react-tooltip";
+
+interface HintProps{
+    children: React.ReactNode
+    text: string
+    side?: "top" | "bottom" | "left" | "right";
+    align?: "start" | "center" | "end";
+}
+
+
+export const Hint = ({children, text, side="top", align="center"}: HintProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <p>{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { Hint } from "@/components/hint";
+import { Button } from "@/components/ui/button";
+import { Fragment } from "@/generated/prisma"
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { useState } from "react";
+
+interface FragmentWebProps {
+    data: Fragment
+}
+
+export const FragmentWeb = ({ data }: FragmentWebProps) => {
+    const [ fragmentKey, setFragmentKey ] = useState(0);
+    const [ copied, setCopied ] = useState(false);
+    const onRefresh = () => {
+        setFragmentKey((prev) => prev + 1);
+    }
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(data.sandboxUrl);
+        setCopied(true);
+        setTimeout(() => {
+            setCopied(false);
+        }, 2000);
+    }
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+        <Hint text="Refresh" side="bottom">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon />
+          </Button>
+        </Hint>
+        <Hint text="Click to copy" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!data.sandboxUrl || copied}
+            className="flex-1 justify-start text-start font-normal"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in a new tab" side="bottom" align="start">
+          <Button
+            size="sm"
+            disabled={!data.sandboxUrl}
+            variant="outline"
+            onClick={() => {
+              if (!data.sandboxUrl) return;
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        title={data.sandboxUrl}
+        src={data.sandboxUrl}
+        className="w-full h-full"
+        sandbox="allow-forms allow-scripts allow-same-origin allow-popups"
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -5,6 +5,7 @@ import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import { ErrorBoundary } from "react-error-boundary";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 
 
 interface ProjectViewProps {
@@ -41,7 +42,7 @@ export const ProjectView = ({ projectId }: ProjectViewProps) => {
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={65} minSize={50}>
-            TODO: Preview
+            {!!activeFragment && <FragmentWeb data={activeFragment}/>}
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a tooltip UI element for enhanced user guidance.
  * Added a preview panel that displays the active fragment with options to refresh, copy, or open the fragment in a new tab.

* **Improvements**
  * Enhanced the user interface by replacing a placeholder with an interactive fragment preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->